### PR TITLE
google: check client credentials only with Sailfish key provider

### DIFF
--- a/src/google/googledatatypesyncadaptor.cpp
+++ b/src/google/googledatatypesyncadaptor.cpp
@@ -60,6 +60,7 @@ void GoogleDataTypeSyncAdaptor::sync(const QString &dataTypeString, int accountI
         return;
     }
 
+#ifdef USE_SAILFISHKEYPROVIDER
     if (clientId().isEmpty()) {
         SOCIALD_LOG_ERROR("client id couldn't be retrieved for Google account" << accountId);
         setStatus(SocialNetworkSyncAdaptor::Error);
@@ -71,6 +72,7 @@ void GoogleDataTypeSyncAdaptor::sync(const QString &dataTypeString, int accountI
         setStatus(SocialNetworkSyncAdaptor::Error);
         return;
     }
+#endif
 
     setStatus(SocialNetworkSyncAdaptor::Busy);
     updateDataForAccount(accountId);
@@ -209,10 +211,16 @@ void GoogleDataTypeSyncAdaptor::signIn(Accounts::Account *account)
 {
     // Fetch consumer key and secret from keyprovider
     int accountId = account->id();
-    if (!checkAccount(account) || clientId().isEmpty() || clientSecret().isEmpty()) {
+    if (!checkAccount(account)) {
         decrementSemaphore(accountId);
         return;
     }
+#ifdef USE_SAILFISHKEYPROVIDER
+    if (clientId().isEmpty() || clientSecret().isEmpty()) {
+        decrementSemaphore(accountId);
+        return;
+    }
+#endif
 
     // grab out a valid identity for the sync service.
     Accounts::Service srv(m_accountManager->service(syncServiceName()));


### PR DESCRIPTION
Accounts not using Sailfish key provider will get their client ID and
secret from the account's AuthData class.