### PR TITLE
[buteo-sync-plugins-social] Don't reset read-only hint to perform mod…

### DIFF
--- a/src/facebook/facebook-calendars/facebookcalendarsyncadaptor.cpp
+++ b/src/facebook/facebook-calendars/facebookcalendarsyncadaptor.cpp
@@ -120,10 +120,10 @@ void FacebookCalendarSyncAdaptor::finalCleanup()
 
         // set the facebook notebook back to read-only
         Q_FOREACH (mKCal::Notebook::Ptr notebook, m_storage->notebooks()) {
-            if (notebook->pluginName() == QLatin1String(FACEBOOK)) {
+            if (notebook->pluginName() == QLatin1String(FACEBOOK)
+                && !notebook->isReadOnly()) {
                 notebook->setIsReadOnly(true);
                 m_storage->updateNotebook(notebook);
-                m_storage->save();
                 break;
             }
         }
@@ -179,9 +179,7 @@ void FacebookCalendarSyncAdaptor::purgeDataForOldAccount(int oldId, SocialNetwor
     foreach (mKCal::Notebook::Ptr notebook, m_storage->notebooks()) {
         if (notebook->pluginName() == QLatin1String(FACEBOOK)
                 && notebook->account() == QString::number(oldId)) {
-            notebook->setIsReadOnly(false);
             m_storage->deleteNotebook(notebook);
-            m_storageNeedsSave = true;
         }
     }
 
@@ -414,7 +412,6 @@ void FacebookCalendarSyncAdaptor::processParsedEvents(int accountId)
         fbNotebook->setDescription(m_accountManager->account(accountId)->displayName());
         fbNotebook->setIsReadOnly(true);
         m_storage->addNotebook(fbNotebook);
-        m_storageNeedsSave = true;
     } else {
         // update the notebook details if required
         bool changed = false;
@@ -425,12 +422,8 @@ void FacebookCalendarSyncAdaptor::processParsedEvents(int accountId)
 
         if (changed) {
             m_storage->updateNotebook(fbNotebook);
-            m_storageNeedsSave = true;
         }
     }
-
-    // Set notebook writeable locally.
-    fbNotebook->setIsReadOnly(false);
 
     // We load incidences that are associated to Facebook into memory
     KCalendarCore::Incidence::List dbEvents;

--- a/src/google/google-calendars/googlecalendarsyncadaptor.cpp
+++ b/src/google/google-calendars/googlecalendarsyncadaptor.cpp
@@ -1132,9 +1132,7 @@ void GoogleCalendarSyncAdaptor::purgeDataForOldAccount(int oldId, SocialNetworkS
         if (notebook->pluginName().startsWith(QStringLiteral("google"))
                 && notebook->account() == QString::number(oldId)) {
             // remove the incidences and delete the notebook
-            notebook->setIsReadOnly(false);
             m_storage->deleteNotebook(notebook);
-            m_storageNeedsSave = true;
         }
     }
 
@@ -2503,7 +2501,6 @@ void GoogleCalendarSyncAdaptor::applyRemoteChangesLocally()
                 mKCal::Notebook::Ptr notebook = mKCal::Notebook::Ptr(new mKCal::Notebook);
                 setCalendarProperties(notebook, calendarInfo, serverCalendarId, m_accountId, syncProfile, ownerEmail);
                 m_storage->addNotebook(notebook);
-                m_storageNeedsSave = true;
             } break;
             case GoogleCalendarSyncAdaptor::Modify: {
                 qCDebug(lcSocialPlugin) << "Modifications required for local notebook for server calendar:" << serverCalendarId;
@@ -2516,7 +2513,6 @@ void GoogleCalendarSyncAdaptor::applyRemoteChangesLocally()
                 } else {
                     setCalendarProperties(notebook, calendarInfo, serverCalendarId, m_accountId, syncProfile, ownerEmail);
                     m_storage->updateNotebook(notebook);
-                    m_storageNeedsSave = true;
                 }
             } break;
             case GoogleCalendarSyncAdaptor::Delete: {
@@ -2526,9 +2522,7 @@ void GoogleCalendarSyncAdaptor::applyRemoteChangesLocally()
                     qCWarning(lcSocialPlugin) << "unable to delete non-existent calendar:" << serverCalendarId << "for account:" << m_accountId;
                     // m_syncSucceeded = false; // don't mark as failed, since the outcome is identical.
                 } else {
-                    notebook->setIsReadOnly(false);
                     m_storage->deleteNotebook(notebook);
-                    m_storageNeedsSave = true;
                 }
             } break;
             case GoogleCalendarSyncAdaptor::DeleteOccurrence: {
@@ -2543,7 +2537,6 @@ void GoogleCalendarSyncAdaptor::applyRemoteChangesLocally()
                 if (!notebook.isNull()) {
                     qCDebug(lcSocialPlugin) << "deleting notebook:" << notebook->uid() << "due to clean sync";
                     notebookUid = notebook->uid();
-                    notebook->setIsReadOnly(false);
                     m_storage->deleteNotebook(notebook);
                 } else {
                     qCDebug(lcSocialPlugin) << "could not find local notebook corresponding to server calendar:" << serverCalendarId;
@@ -2556,7 +2549,6 @@ void GoogleCalendarSyncAdaptor::applyRemoteChangesLocally()
                 }
                 setCalendarProperties(notebook, calendarInfo, serverCalendarId, m_accountId, syncProfile, ownerEmail);
                 m_storage->addNotebook(notebook);
-                m_storageNeedsSave = true;
             } break;
         }
     }
@@ -2779,7 +2771,6 @@ void GoogleCalendarSyncAdaptor::updateLocalCalendarNotebookEvents(const QString 
     m_storage->allIncidences(&allLocalEventsList, googleNotebook->uid());
 
     // write changes required to complete downsync to local database
-    googleNotebook->setIsReadOnly(false);
     if (!changesFromDownsyncForCalendar.isEmpty()) {
         // build the partial-upsync-artifact mapping for this set of changes.
         QHash<QString, QString> upsyncedUidMapping;


### PR DESCRIPTION
…ifications. Contributes to JB#59227

@pvuorela, yet another follow-up of sailfishos/mkcal#34. I've removed also the flagging for incidence save on notebook changes. This is correct, but may induce regressions if the flag was set there and covering a missing set on an event update for instance. What do you think ?