### PR TITLE
[buteo-sync-plugins-social] mKCal is now always loading series.

### DIFF
--- a/src/google/google-calendars/googlecalendarsyncadaptor.cpp
+++ b/src/google/google-calendars/googlecalendarsyncadaptor.cpp
@@ -3091,7 +3091,7 @@ void GoogleCalendarSyncAdaptor::applySyncFailureFlags()
         KCalendarCore::Event::Ptr event = m_calendar->event(uid);
         if (!event) {
             // Load it if it wasn't already
-            m_storage->loadSeries(uid);
+            m_storage->load(uid);
             event = m_calendar->event(uid);
         }
 


### PR DESCRIPTION
When loading an incidence by UID from the database, the full series is always loaded, ensuring that
exceptions exist, if any, in the calendar.

@pvuorela, a minor modification following sailfishos/mkcal#47.