### PR TITLE
[buteo-sync-plugins-social] Provide notebook uid when purging deleted…

### DIFF
--- a/src/google/google-calendars/googlecalendarsyncadaptor.h
+++ b/src/google/google-calendars/googlecalendarsyncadaptor.h
@@ -78,6 +78,7 @@ private:
         UpsyncChange() : upsyncType(NoChange) {}
         QString accessToken;
         ChangeType upsyncType;
+        QString kcalNotebookId;
         QString kcalEventId;
         QDateTime recurrenceId;
         QString calendarId;
@@ -185,7 +186,7 @@ private:
     QMultiMap<QString, QPair<KCalendarCore::Event::Ptr, QJsonObject> > m_changesFromUpsync; // calendarId to event+upsyncResponse
     QSet<QString> m_syncTokenFailure; // calendarIds suffering from 410 error due to invalid sync token
     QSet<QString> m_timeMinFailure;   // calendarIds suffering from 410 error due to invalid timeMin value
-    KCalendarCore::Incidence::List m_purgeList;
+    QMap<QString, KCalendarCore::Incidence::List> m_purgeList; // notebookIds to local deleted incidences that can be purged
     QMap<QString, KCalendarCore::Incidence::Ptr> m_deletedGcalIdToIncidence;
 
     mKCal::ExtendedCalendar::Ptr m_calendar;


### PR DESCRIPTION
… calendar events.

Provides the notebook UID of the event to
purge. Not a necessity at the moment since
event UIDs are unique in the database, but
it will allow to raise the unicity constrain
between notebooks later on.

@pvuorela, this is a follow-up of sailfishos/mkcal#59. Unfortunately, it is introducing larger changes than expected. I don't use any Google account, so it's a bit tricky for me to test. I can use mine if you think it can help checking and merging this though.