### PR TITLE
[buteo-sync-plugins-social] Adapt to libsocialcache downloader api. JB#59640

### DIFF
--- a/src/google/google-contacts/googlecontactimagedownloader.cpp
+++ b/src/google/google-contacts/googlecontactimagedownloader.cpp
@@ -35,7 +35,8 @@ GoogleContactImageDownloader::GoogleContactImageDownloader()
 
 QString GoogleContactImageDownloader::staticOutputFile(const QString &identifier, const QUrl &url)
 {
-    return makeOutputFile(SocialSyncInterface::Google, SocialSyncInterface::Contacts, identifier, url.toString());
+    return makeUrlOutputFile(SocialSyncInterface::Google, SocialSyncInterface::Contacts, identifier,
+                             url.toString(), QString());
 }
 
 QNetworkReply * GoogleContactImageDownloader::createReply(const QString &url,
@@ -50,7 +51,10 @@ QNetworkReply * GoogleContactImageDownloader::createReply(const QString &url,
     return d->networkAccessManager->get(request);
 }
 
-QString GoogleContactImageDownloader::outputFile(const QString &url, const QVariantMap &data) const
+QString GoogleContactImageDownloader::outputFile(const QString &url,
+                                                 const QVariantMap &data,
+                                                 const QString &mimeType) const
 {
+    Q_UNUSED(mimeType); // TODO: use
     return staticOutputFile(data.value(IMAGE_DOWNLOADER_IDENTIFIER_KEY).toString(), url);
 }

--- a/src/google/google-contacts/googlecontactimagedownloader.h
+++ b/src/google/google-contacts/googlecontactimagedownloader.h
@@ -41,7 +41,7 @@ public:
 protected:
     QNetworkReply * createReply(const QString &url, const QVariantMap &metadata);
     // This is a reimplemented method, used by AbstractImageDownloader
-    QString outputFile(const QString &url, const QVariantMap &data) const;
+    QString outputFile(const QString &url, const QVariantMap &data, const QString &mimeType) const override;
 private:
     Q_DECLARE_PRIVATE(AbstractImageDownloader)
 };

--- a/src/google/google-contacts/googlepeoplejson.cpp
+++ b/src/google/google-contacts/googlepeoplejson.cpp
@@ -971,7 +971,7 @@ bool GooglePeople::Photo::saveContactDetails(QContact *contact, const QList<Phot
         const QString localFilePath = GoogleContactImageDownloader::staticOutputFile(guid, photo.url);
         if (localFilePath.isEmpty()) {
             qCWarning(lcSocialPlugin) << "Cannot generate local file name for avatar url:" << photo.url
-                              << "for contact:" << guid;
+                                      << "for contact:" << guid;
             continue;
         }
 

--- a/src/vk/vk-contacts/vkcontactimagedownloader.cpp
+++ b/src/vk/vk-contacts/vkcontactimagedownloader.cpp
@@ -20,7 +20,8 @@ VKContactImageDownloader::VKContactImageDownloader()
 
 QString VKContactImageDownloader::staticOutputFile(const QString &identifier, const QUrl &url)
 {
-    return makeOutputFile(SocialSyncInterface::VK, SocialSyncInterface::Contacts, identifier, url.toString());
+    return makeUrlOutputFile(SocialSyncInterface::VK, SocialSyncInterface::Contacts, identifier,
+                             url.toString(), QString());
 }
 
 QNetworkReply * VKContactImageDownloader::createReply(const QString &url,
@@ -34,7 +35,9 @@ QNetworkReply * VKContactImageDownloader::createReply(const QString &url,
     return d->networkAccessManager->get(request);
 }
 
-QString VKContactImageDownloader::outputFile(const QString &url, const QVariantMap &data) const
+QString VKContactImageDownloader::outputFile(const QString &url, const QVariantMap &data,
+                                             const QString &mimeType) const
 {
+    Q_UNUSED(mimeType); // TODO: use
     return staticOutputFile(data.value(IMAGE_DOWNLOADER_IDENTIFIER_KEY).toString(), url);
 }

--- a/src/vk/vk-contacts/vkcontactimagedownloader.h
+++ b/src/vk/vk-contacts/vkcontactimagedownloader.h
@@ -27,7 +27,7 @@ public:
 protected:
     QNetworkReply * createReply(const QString &url, const QVariantMap &metadata);
     // This is a reimplemented method, used by AbstractImageDownloader
-    QString outputFile(const QString &url, const QVariantMap &data) const;
+    QString outputFile(const QString &url, const QVariantMap &data, const QString &mimeType) const override;
 private:
     Q_DECLARE_PRIVATE(AbstractImageDownloader)
 };


### PR DESCRIPTION
Mimetype hint added to output file generation functions. For keeping this simple, not yet adapting to use it.

Depends on https://github.com/sailfishos/libsocialcache/pull/3