### PR TITLE
Export libbuteosocialcommon as devel API and fix template sync result

### DIFF
--- a/rpm/buteo-sync-plugins-social.spec
+++ b/rpm/buteo-sync-plugins-social.spec
@@ -80,6 +80,13 @@ Requires: %{name} = %{version}-%{release}
 Buteo sync plugin that stores locally created contacts, such as email
 recipients.
 
+%package devel
+Summary: Development files for social sync plugin common library
+Requires: %{name} = %{version}-%{release}
+
+%description devel
+Headers and pkg-config metadata for linking against libbuteosocialcommon.
+
 %package ts-devel
 Summary:    Translation source for sociald
 
@@ -262,8 +269,8 @@ done
 %{_libdir}/buteo-plugins-qt5/oopp/libsociald-client.so
 %config %{_sysconfdir}/buteo/profiles/client/sociald.xml
 %config %{_sysconfdir}/buteo/profiles/sync/sociald.All.xml
-%{_libdir}/libsyncpluginscommon.so.*
-%exclude %{_libdir}/libsyncpluginscommon.so
+%{_libdir}/libbuteosocialcommon.so.*
+%exclude %{_libdir}/libbuteosocialcommon.so
 %license COPYING
 
 %files facebook
@@ -367,6 +374,11 @@ done
 %config %{_sysconfdir}/buteo/profiles/sync/dropbox.Backup.xml
 %config %{_sysconfdir}/buteo/profiles/sync/dropbox.BackupQuery.xml
 %config %{_sysconfdir}/buteo/profiles/sync/dropbox.BackupRestore.xml
+
+%files devel
+%{_includedir}/buteosocialcommon/*.h
+%{_libdir}/libbuteosocialcommon.so
+%{_libdir}/pkgconfig/buteosocialcommon.pc
 
 %files knowncontacts
 %{_libdir}/buteo-plugins-qt5/oopp/libknowncontacts-client.so

--- a/rpm/buteo-sync-plugins-social.spec
+++ b/rpm/buteo-sync-plugins-social.spec
@@ -80,6 +80,13 @@ Requires: %{name} = %{version}-%{release}
 Buteo sync plugin that stores locally created contacts, such as email
 recipients.
 
+%package devel
+Summary: Development files for social sync plugin common library
+Requires: %{name} = %{version}-%{release}
+
+%description devel
+Development files for linking against libbuteosocialcommon.
+
 %package ts-devel
 Summary:    Translation source for sociald
 
@@ -262,8 +269,8 @@ done
 %{_libdir}/buteo-plugins-qt5/oopp/libsociald-client.so
 %config %{_sysconfdir}/buteo/profiles/client/sociald.xml
 %config %{_sysconfdir}/buteo/profiles/sync/sociald.All.xml
-%{_libdir}/libsyncpluginscommon.so.*
-%exclude %{_libdir}/libsyncpluginscommon.so
+%{_libdir}/libbuteosocialcommon.so.*
+%exclude %{_libdir}/libbuteosocialcommon.so
 %license COPYING
 
 %files facebook
@@ -367,6 +374,11 @@ done
 %config %{_sysconfdir}/buteo/profiles/sync/dropbox.Backup.xml
 %config %{_sysconfdir}/buteo/profiles/sync/dropbox.BackupQuery.xml
 %config %{_sysconfdir}/buteo/profiles/sync/dropbox.BackupRestore.xml
+
+%files devel
+%{_includedir}/buteosocialcommon/*.h
+%{_libdir}/libbuteosocialcommon.so
+%{_libdir}/pkgconfig/buteosocialcommon.pc
 
 %files knowncontacts
 %{_libdir}/buteo-plugins-qt5/oopp/libknowncontacts-client.so

--- a/src/common.pri
+++ b/src/common.pri
@@ -21,7 +21,7 @@ DEFINES += 'SYNC_DATABASE_DIR=\'\"Sync\"\''
 
 INCLUDEPATH += . $$PWD/common/
 
-LIBS += -L$$PWD/common -lsyncpluginscommon
+LIBS += -L$$PWD/common -lbuteosocialcommon
 
 contains(DEFINES, 'SOCIALD_USE_QTPIM') {
     DEFINES *= USE_CONTACTS_NAMESPACE=QTCONTACTS_USE_NAMESPACE

--- a/src/common/buteosocialcommon.pc
+++ b/src/common/buteosocialcommon.pc
@@ -1,0 +1,12 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include/buteosocialcommon
+
+Name: buteosocialcommon
+Description: Common support library for social sync plugins
+Version: 0.4.0
+Requires: accounts-qt5 buteosyncfw5 socialcache
+Requires.private: Qt5Network Qt5DBus
+Libs: -L${libdir} -lbuteosocialcommon
+Cflags: -I${includedir}

--- a/src/common/buteosyncfw_p.h
+++ b/src/common/buteosyncfw_p.h
@@ -22,6 +22,8 @@
 #ifndef SOCIALD_BUTEOSYNCFW_P_H
 #define SOCIALD_BUTEOSYNCFW_P_H
 
+#include <QStandardPaths>
+
 #include <SyncCommonDefs.h>
 #include <SyncPluginBase.h>
 #include <ProfileManager.h>

--- a/src/common/common.pro
+++ b/src/common/common.pro
@@ -3,17 +3,22 @@ TEMPLATE = lib
 QT -= gui
 QT += network dbus
 
+isEmpty(PREFIX) {
+    PREFIX=/usr
+}
+
 CONFIG += link_pkgconfig
 PKGCONFIG += \
     accounts-qt5 \
     buteosyncfw5 \
     socialcache \
 
-TARGET = syncpluginscommon
+TARGET = buteosocialcommon
 TARGET = $$qtLibraryTarget($$TARGET)
 
 HEADERS += \
     $$PWD/buteosyncfw_p.h \
+    $$PWD/constants_p.h \
     $$PWD/socialdbuteoplugin.h \
     $$PWD/socialnetworksyncadaptor.h \
     $$PWD/socialdnetworkaccessmanager_p.h \
@@ -27,5 +32,11 @@ SOURCES += \
 
 TARGETPATH = $$[QT_INSTALL_LIBS]
 target.path = $$TARGETPATH
+common_headers.path = $$PREFIX/include/buteosocialcommon
+common_headers.files = \
+    $$PWD/socialdbuteoplugin.h \
+    $$PWD/socialnetworksyncadaptor.h
+common_pkgconfig.path = $$[QT_INSTALL_LIBS]/pkgconfig
+common_pkgconfig.files = $$PWD/buteosocialcommon.pc
 
-INSTALLS += target
+INSTALLS += target common_headers common_pkgconfig

--- a/src/common/common.pro
+++ b/src/common/common.pro
@@ -3,17 +3,25 @@ TEMPLATE = lib
 QT -= gui
 QT += network dbus
 
+isEmpty(PREFIX) {
+    PREFIX=/usr
+}
+
 CONFIG += link_pkgconfig
 PKGCONFIG += \
     accounts-qt5 \
     buteosyncfw5 \
     socialcache \
 
-TARGET = syncpluginscommon
+# qmake's pkg-config generation relies on prl generation internals.
+CONFIG += create_pc create_prl no_install_prl
+
+TARGET = buteosocialcommon
 TARGET = $$qtLibraryTarget($$TARGET)
 
 HEADERS += \
     $$PWD/buteosyncfw_p.h \
+    $$PWD/constants_p.h \
     $$PWD/socialdbuteoplugin.h \
     $$PWD/socialnetworksyncadaptor.h \
     $$PWD/socialdnetworkaccessmanager_p.h \
@@ -27,5 +35,19 @@ SOURCES += \
 
 TARGETPATH = $$[QT_INSTALL_LIBS]
 target.path = $$TARGETPATH
+common_headers.path = $$PREFIX/include/buteosocialcommon
+common_headers.files = \
+    $$PWD/socialdbuteoplugin.h \
+    $$PWD/socialnetworksyncadaptor.h
+INSTALLS += target common_headers
 
-INSTALLS += target
+QMAKE_PKGCONFIG_DESTDIR = pkgconfig
+QMAKE_PKGCONFIG_PREFIX = $$PREFIX
+QMAKE_PKGCONFIG_LIBDIR = $$target.path
+QMAKE_PKGCONFIG_INCDIR = $$common_headers.path
+QMAKE_PKGCONFIG_NAME = buteosocialcommon
+QMAKE_PKGCONFIG_FILE = buteosocialcommon
+QMAKE_PKGCONFIG_DESCRIPTION = Common support library for social sync plugins
+QMAKE_PKGCONFIG_REQUIRES = buteosyncfw5
+QMAKE_PKGCONFIG_VERSION = 1.0.0
+pkgconfig.files = $${QMAKE_PKGCONFIG_FILE}.pc

--- a/src/common/socialdbuteoplugin.cpp
+++ b/src/common/socialdbuteoplugin.cpp
@@ -149,11 +149,16 @@ bool SocialdButeoPlugin::uninit()
 
 bool SocialdButeoPlugin::startSync()
 {
+    if (!m_socialNetworkSyncAdaptor || !m_socialNetworkSyncAdaptor->enabled()) {
+        qCDebug(lcSocialPlugin) << "no enabled" << m_socialServiceName << "sync adaptor for" << m_dataTypeName;
+        return false;
+    }
+
     // if the profile being triggered is the template profile, then we
     // need to ensure that the appropriate per-account profiles exist.
     if (m_profileAccountId == 0) {
         QList<Buteo::SyncProfile*> perAccountProfiles = ensurePerAccountSyncProfilesExist();
-        m_socialNetworkSyncAdaptor->setAccountSyncProfile(NULL);
+        m_socialNetworkSyncAdaptor->setAccountSyncProfile(nullptr);
 
         // we need to trigger sync with each profile separately,
         // or (due to scheduling/etc) another plugin instance might
@@ -165,25 +170,30 @@ bool SocialdButeoPlugin::startSync()
             message.setArguments(QVariantList() << perAccountProfile->name());
             QDBusConnection::sessionBus().asyncCall(message);
         }
-    } else {
-        m_socialNetworkSyncAdaptor->setAccountSyncProfile(profile().clone());
+        qDeleteAll(perAccountProfiles);
+
+        // This template profile only dispatches account-specific sync profiles.
+        // Avoid running account-specific adaptors with accountId == 0, which
+        // would otherwise report a spurious sync error for the template run.
+        // Child sync runs report their own individual results.
+        updateResults(Buteo::SyncResults(QDateTime::currentDateTime(),
+                                         Buteo::SyncResults::SYNC_RESULT_SUCCESS,
+                                         Buteo::SyncResults::NO_ERROR));
+        emit success(getProfileName(), QString("%1 update dispatched").arg(getProfileName()));
+        return true;
     }
 
-    // now perform sync.  Note that for the template profile case, this will
-    // result in a purge operation occurring (checking for removed accounts and
-    // purging any synced data associated with those accounts).
-    if (m_socialNetworkSyncAdaptor && m_socialNetworkSyncAdaptor->enabled()) {
-        if (m_socialNetworkSyncAdaptor->status() == SocialNetworkSyncAdaptor::Inactive) {
-            qCDebug(lcSocialPlugin) << "performing sync of" << m_dataTypeName << "from" << m_socialServiceName
-                                    << "for account" << m_profileAccountId;
-            m_socialNetworkSyncAdaptor->sync(m_dataTypeName, m_profileAccountId);
-            return true;
-        } else {
-            qCDebug(lcSocialPlugin) << m_socialServiceName << "sync adaptor for" << m_dataTypeName
-                                    << "is still busy with last sync of account" << m_profileAccountId;
-        }
+    m_socialNetworkSyncAdaptor->setAccountSyncProfile(profile().clone());
+
+    // Now perform sync for the account-specific profile.
+    if (m_socialNetworkSyncAdaptor->status() == SocialNetworkSyncAdaptor::Inactive) {
+        qCDebug(lcSocialPlugin) << "performing sync of" << m_dataTypeName << "from" << m_socialServiceName
+                                << "for account" << m_profileAccountId;
+        m_socialNetworkSyncAdaptor->sync(m_dataTypeName, m_profileAccountId);
+        return true;
     } else {
-        qCDebug(lcSocialPlugin) << "no enabled" << m_socialServiceName << "sync adaptor for" << m_dataTypeName;
+        qCDebug(lcSocialPlugin) << m_socialServiceName << "sync adaptor for" << m_dataTypeName
+                                << "is still busy with last sync of account" << m_profileAccountId;
     }
     return false;
 }

--- a/src/common/socialdbuteoplugin.h
+++ b/src/common/socialdbuteoplugin.h
@@ -23,7 +23,14 @@
 #define SOCIALDBUTEOPLUGIN_H
 
 #include <QtCore/qglobal.h>
-#include "buteosyncfw_p.h"
+
+// Buteo
+#include <ClientPlugin.h>
+#include <ProfileManager.h>
+#include <PluginCbInterface.h>
+#include <SyncCommonDefs.h>
+#include <SyncProfile.h>
+#include <SyncResults.h>
 
 /*
    Datatype-specific implementations of this class

--- a/src/common/socialnetworksyncadaptor.h
+++ b/src/common/socialnetworksyncadaptor.h
@@ -30,7 +30,10 @@
 #include <QtCore/QMap>
 #include <QtCore/QList>
 
-#include "buteosyncfw_p.h"
+// Buteo
+#include <SyncCommonDefs.h>
+#include <ProfileEngineDefs.h>
+#include <SyncProfile.h>
 
 class QNetworkAccessManager;
 class QTimer;

--- a/src/dropbox/dropbox-images/dropboximagesyncadaptor.cpp
+++ b/src/dropbox/dropbox-images/dropboximagesyncadaptor.cpp
@@ -28,6 +28,7 @@
 #include <QtCore/QVariantMap>
 #include <QtCore/QByteArray>
 #include <QtCore/QUrlQuery>
+#include <QtCore/QJsonDocument>
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlError>

--- a/src/dropbox/dropboxbackupoperationsyncadaptor.cpp
+++ b/src/dropbox/dropboxbackupoperationsyncadaptor.cpp
@@ -25,6 +25,7 @@
 #include <QtCore/QDir>
 #include <QtCore/QUrl>
 #include <QtCore/QVariantMap>
+#include <QtCore/QJsonDocument>
 #include <QtNetwork/QNetworkReply>
 #include <QtNetwork/QSslError>
 #include <QtDBus/QDBusConnection>

--- a/src/facebook/facebook-calendars/facebookcalendarsyncadaptor.cpp
+++ b/src/facebook/facebook-calendars/facebookcalendarsyncadaptor.cpp
@@ -21,11 +21,14 @@
 
 #include "facebookcalendarsyncadaptor.h"
 #include "trace.h"
+#include "buteosyncfw_p.h"
 
 #include <QtCore/QUrlQuery>
 #include <QtCore/QFile>
 #include <QtCore/QDir>
 #include <QtCore/QJsonArray>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QUuid>
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlError>
 #include <QtNetwork/QHttpMultiPart>

--- a/src/google/google-calendars/googlecalendarsyncadaptor.cpp
+++ b/src/google/google-calendars/googlecalendarsyncadaptor.cpp
@@ -22,6 +22,7 @@
 #include "googlecalendarsyncadaptor.h"
 #include "googlecalendarincidencecomparator.h"
 #include "trace.h"
+#include "buteosyncfw_p.h"
 
 #include <QtCore/QUrlQuery>
 #include <QtCore/QFile>
@@ -30,6 +31,7 @@
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonObject>
 #include <QtCore/QJsonDocument>
+#include <QtCore/QUuid>
 #include <QtCore/QSettings>
 #include <QtCore/QSet>
 

--- a/src/google/google-contacts/googletwowaycontactsyncadaptor.cpp
+++ b/src/google/google-contacts/googletwowaycontactsyncadaptor.cpp
@@ -24,6 +24,7 @@
 
 #include "constants_p.h"
 #include "trace.h"
+#include "buteosyncfw_p.h"
 
 #include <twowaycontactsyncadaptor_impl.h>
 #include <qtcontacts-extensions_manager_impl.h>

--- a/src/onedrive/onedrivebackupoperationsyncadaptor.h
+++ b/src/onedrive/onedrivebackupoperationsyncadaptor.h
@@ -28,6 +28,8 @@
 #include <QtCore/QStringList>
 #include <QtCore/QFileInfo>
 
+class QDBusInterface;
+
 class OneDriveBackupOperationSyncAdaptor : public OneDriveDataTypeSyncAdaptor
 {
     Q_OBJECT

--- a/src/vk/vk-calendars/vkcalendarsyncadaptor.cpp
+++ b/src/vk/vk-calendars/vkcalendarsyncadaptor.cpp
@@ -12,6 +12,7 @@
 #include <QtCore/QFile>
 #include <QtCore/QDir>
 #include <QtCore/QJsonArray>
+#include <QtCore/QUuid>
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlError>
 

--- a/src/vk/vk-posts/vkpostsyncadaptor.cpp
+++ b/src/vk/vk-posts/vkpostsyncadaptor.cpp
@@ -8,6 +8,7 @@
 #include "vkpostsyncadaptor.h"
 #include "trace.h"
 #include "constants_p.h"
+#include "buteosyncfw_p.h"
 
 #include <QtCore/QPair>
 #include <QtCore/QJsonArray>

--- a/src/vk/vkdatatypesyncadaptor.h
+++ b/src/vk/vkdatatypesyncadaptor.h
@@ -12,6 +12,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QString>
+#include <QtCore/QTimer>
 #include <QtCore/QVariantList>
 #include <QtNetwork/QNetworkReply>
 #include <QtNetwork/QSslError>


### PR DESCRIPTION
- Rename shared common lib to libbuteosocialcommon.
- Install headers and pkg-config metadata as -devel package.
- Keep template profile sync as dispatch-only and report success immediately, avoiding spurious accountId==0 sync errors.