### PR TITLE
[buteo-sync-plugins-social] Schedule Google contacts and calendar syn…

### DIFF
--- a/src/google/google-calendars/google.Calendars.xml
+++ b/src/google/google-calendars/google.Calendars.xml
@@ -7,7 +7,7 @@
     <key name="hidden" value="true" />
     <key name="displayname" value="Google Calendars"/>
 
-    <schedule enabled="false" interval="" days="1,2,3,4,5,6,7" syncconfiguredtime="" time="05:00:00" />
+    <schedule enabled="false" interval="720" days="1,2,3,4,5,6,7" syncconfiguredtime="" time="" />
 
     <profile name="google-calendars" type="client" >
         <key name="Sync Direction" value="two-way" />

--- a/src/google/google-contacts/google.Contacts.xml
+++ b/src/google/google-contacts/google.Contacts.xml
@@ -7,7 +7,7 @@
     <key name="hidden" value="true" />
     <key name="displayname" value="Google Contacts"/>
 
-    <schedule enabled="false" interval="" days="1,2,3,4,5,6,7" syncconfiguredtime="" time="05:00:00" />
+    <schedule enabled="false" interval="720" days="1,2,3,4,5,6,7" syncconfiguredtime="" time="" />
 
     <profile name="google-contacts" type="client" >
         <key name="Sync Direction" value="two-way" />


### PR DESCRIPTION
…c twice a day.

Change the default for Google contacts and
calendar to a sync schedule of twice a day.

@pvuorela, in case we change the UI selection to allow an interval choice.